### PR TITLE
Added option for adding tenant ID from header.

### DIFF
--- a/server/middleware/tenant-parser.js
+++ b/server/middleware/tenant-parser.js
@@ -1,6 +1,6 @@
 module.exports = function() {
   return function tenantParser(req, res, next) {
-    req.tenantId = req.query.tenant || 1;
+    req.tenantId = req.query.tenant || (req.headers['x-tenant-id'] || 1);
 
     console.log('TR middleware triggered', req.tenantId);
 


### PR DESCRIPTION
### Overview

Instead of making URL combination with tenant query parameter, users can able to pass the tenant ID from header (a common header for all API calls). 

#### Related issues

- None

### Checklist

- None